### PR TITLE
Return hash from ethers wallet txs rather than full TransactionResponse

### DIFF
--- a/.changeset/many-ads-perform.md
+++ b/.changeset/many-ads-perform.md
@@ -1,0 +1,5 @@
+---
+'@tokenbound/sdk': patch
+---
+
+set ethers executeCall and createAccount return types to hash

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -18,7 +18,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest --watch=false",
     "coverage": "vitest run --coverage",
     "clean": "rm -rf node_modules/"
   },

--- a/packages/sdk/src/TokenboundClient.ts
+++ b/packages/sdk/src/TokenboundClient.ts
@@ -9,7 +9,7 @@ import {
   executeCall,
   prepareCreateAccount
 } from './functions'
-import { AbstractEthersSigner } from "./types"
+import { AbstractEthersSigner, AbstractEthersTransactionResponse } from "./types"
 import { chainIdToChain } from "./utils"
 
 export type TokenboundClientOptions = {
@@ -156,7 +156,9 @@ class TokenboundClient {
           implementationAddress: implementation,
           registryAddress: registry
         })
-        return await this.signer.sendTransaction(prepareCreateAccount)
+
+        // Extract the txHash from the TransactionResponse
+        return await this.signer.sendTransaction(prepareCreateAccount).then((tx:AbstractEthersTransactionResponse) => tx.hash) as `0x${string}`
 
       }
       else if(this.walletClient) {
@@ -194,7 +196,7 @@ class TokenboundClient {
  * @param {string} params.to The recipient address
  * @param {bigint} params.value The value to send, in wei
  * @param {string} params.data The data to send
- * @returns a Promise with prepared transaction to execute a call on a tokenbound account. Can be sent via `sendTransaction` on an Ethers signer or viem WalletClient.
+ * @returns a Promise that resolves to the transaction hash of the executed call
  */
   public async executeCall(params: ExecuteCallParams): Promise<`0x${string}`> {
     const { account, to, value, data } = params
@@ -209,7 +211,8 @@ class TokenboundClient {
 
     try {
       if(this.signer) { // Ethers
-        return await this.signer.sendTransaction(preparedExecuteCall)
+        // Extract the txHash from the TransactionResponse
+        return  await this.signer.sendTransaction(preparedExecuteCall).then((tx: AbstractEthersTransactionResponse) => tx.hash) as `0x${string}`
       }
       else if(this.walletClient) {
         return await this.walletClient.sendTransaction({

--- a/packages/sdk/src/types/abstractEthersTransactionResponse.ts
+++ b/packages/sdk/src/types/abstractEthersTransactionResponse.ts
@@ -1,0 +1,8 @@
+
+// We check for the existence of the hash as loose verification that a response is
+// an Ethers TransactionResponse without first importing the Ethers package.
+// This AbstractEthersTransactionResponse type assures that there is at least some degree of type safety on the Ethers implementation of the TokenboundClient.
+
+export type AbstractEthersTransactionResponse = {
+    hash: string
+} & Record<string, any>

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './abstractEthersSigner'
 export * from './abstractBigNumber'
+export * from './abstractEthersTransactionResponse'


### PR DESCRIPTION
For consistency with the default viem client, this PR ensures that the return type from ```executeCall``` and ```createAccount``` is the transaction hash. Previously the full ```TransactionResponse``` was being returned.