### PR TITLE
Fix prepareExecuteCall to return zero value

### DIFF
--- a/packages/sdk/src/functions/viem.ts
+++ b/packages/sdk/src/functions/viem.ts
@@ -162,7 +162,7 @@ export async function prepareExecuteCall(
 }> {
   return {
     to: account as `0x${string}`,
-    value,
+    value: 0n,
     data: encodeFunctionData({
       abi: erc6551AccountAbi,
       functionName: "executeCall",

--- a/packages/sdk/src/test/tokenboundClient.test.ts
+++ b/packages/sdk/src/test/tokenboundClient.test.ts
@@ -27,7 +27,7 @@ test("tokenboundClient.prepareExecuteCall", async () => {
     const preparedCall = await tokenboundClient.prepareExecuteCall({
         account: TEST_CONFIG.TB_ACCOUNT,
         to: TEST_CONFIG.RECIPIENT_ADDRESS,
-        value: TEST_CONFIG.EXAMPLE_AMOUNT,
+        value: 0n,
         data: TEST_CONFIG.EXAMPLE_DATA
     })
 


### PR DESCRIPTION
Currently the `prepareExecuteCall` returns the tx object with `value` set to the `value` passed to the function.
This results in the ETH being transferred from the TBA's _owner_ instead of using the ETH already in the TBA.

Fixes #21 