### PR TITLE
Add GitHub release workflow

### DIFF
--- a/.github/workflows/on-create-release.yml
+++ b/.github/workflows/on-create-release.yml
@@ -1,0 +1,38 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18]
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Set up PNPM
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      # Navigate to the specific package directory within the monorepo
+      - name: Change to package directory
+        run: cd packages/sdk
+
+      - name: Install dependencies and build 🔧
+        run: pnpm ci && pnpm build
+
+      - name: Publish package on NPM 📦
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub workflow that publishes a package to NPM when a new release is published on the SDK repository. 

In so doing, this ensures that:
- We are actually creating releases + release notes / change logs in GitHub
- We are properly handling versioning
- We have control over the release cadence, vs. simply publishing on push to main

In tandem, we have new restrictions that disallow push to main except via PR. This can be overridden with a force push, but these changes should limit mistaken pushes to main that can cause issues, especially when external contributors are cloning from main.