### PR TITLE
Eliminate non-deployed chains from build

### DIFF
--- a/.changeset/yellow-pigs-stare.md
+++ b/.changeset/yellow-pigs-stare.md
@@ -1,0 +1,5 @@
+---
+'@tokenbound/sdk': patch
+---
+
+Eliminate non-deployed chains from build

--- a/.github/workflows/on-create-release.yml
+++ b/.github/workflows/on-create-release.yml
@@ -29,7 +29,10 @@ jobs:
       - name: Change to package directory
         run: cd packages/sdk
 
-      - name: Install dependencies and build 🔧
+      - name: Install dependencies
+        run: npm install
+
+      - name: Clean install and build 🔧
         run: npm ci && npm build
         # run: pnpm ci && pnpm build // pnpm ci not yet implemented: https://github.com/pnpm/pnpm/issues/6100
 

--- a/examples/vite-wagmi-ethers-rainbowkit/package.json
+++ b/examples/vite-wagmi-ethers-rainbowkit/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.5",
-    "viem": "^1.15.4",
+    "viem": "^1.16.2",
     "wagmi": "^1.4.3"
   },
   "devDependencies": {

--- a/examples/vite-wagmi-ethers-rainbowkit/package.json
+++ b/examples/vite-wagmi-ethers-rainbowkit/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.5",
-    "viem": "^1.15.1",
+    "viem": "^1.15.4",
     "wagmi": "^1.4.3"
   },
   "devDependencies": {

--- a/examples/vite-wagmi-ethers/package.json
+++ b/examples/vite-wagmi-ethers/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.5",
-    "viem": "^1.15.4",
+    "viem": "^1.16.2",
     "wagmi": "^1.4.3"
   },
   "devDependencies": {

--- a/examples/vite-wagmi-ethers/package.json
+++ b/examples/vite-wagmi-ethers/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.5",
-    "viem": "^1.15.1",
+    "viem": "^1.15.4",
     "wagmi": "^1.4.3"
   },
   "devDependencies": {

--- a/examples/vite-wagmi-ethers6/package.json
+++ b/examples/vite-wagmi-ethers6/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.5",
-    "viem": "^1.15.4",
+    "viem": "^1.16.2",
     "wagmi": "^1.4.3"
   },
   "devDependencies": {

--- a/examples/vite-wagmi-ethers6/package.json
+++ b/examples/vite-wagmi-ethers6/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.5",
-    "viem": "^1.15.1",
+    "viem": "^1.15.4",
     "wagmi": "^1.4.3"
   },
   "devDependencies": {

--- a/examples/vite-wagmi-viem/package.json
+++ b/examples/vite-wagmi-viem/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.5",
-    "viem": "^1.15.4",
+    "viem": "^1.16.2",
     "wagmi": "^1.4.3"
   },
   "devDependencies": {

--- a/examples/vite-wagmi-viem/package.json
+++ b/examples/vite-wagmi-viem/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.5",
-    "viem": "^1.15.1",
+    "viem": "^1.15.4",
     "wagmi": "^1.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "workspaces": [
+    "packages/sdk"
+  ],
+  "publishConfig.directory": {
+    "directory": "packages/sdk"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "eslint": "^8.50.0",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "workspaces": [
-    "packages/sdk"
-  ],
   "publishConfig.directory": {
     "directory": "packages/sdk"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,7 +25,7 @@
     "wagmi": "wagmi generate"
   },
   "dependencies": {
-    "viem": "^1.15.4"
+    "viem": "^1.16.2"
   },
   "devDependencies": {
     "@tanstack/react-query": "4.29.1",
@@ -45,7 +45,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.2.2",
-    "viem": "^1.15.4",
+    "viem": "^1.16.2",
     "@viem/anvil": "^0.0.6",
     "vite": "^4.4.9",
     "vite-plugin-dts": "^3.5.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenbound/sdk",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "type": "module",
   "files": [
     "dist"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenbound/sdk",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "type": "module",
   "files": [
     "dist"
@@ -25,7 +25,7 @@
     "wagmi": "wagmi generate"
   },
   "dependencies": {
-    "viem": "^1.14.0"
+    "viem": "^1.15.4"
   },
   "devDependencies": {
     "@tanstack/react-query": "4.29.1",
@@ -45,7 +45,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.2.2",
-    "viem": "^1.15.1",
+    "viem": "^1.15.4",
     "@viem/anvil": "^0.0.6",
     "vite": "^4.4.9",
     "vite-plugin-dts": "^3.5.1",

--- a/packages/sdk/src/TokenboundClient.ts
+++ b/packages/sdk/src/TokenboundClient.ts
@@ -76,8 +76,8 @@ class TokenboundClient {
       publicClientRPCUrl,
     } = options
 
-    if (!chainId) {
-      throw new Error('chainId is required.')
+    if (!chainId && !chain) {
+      throw new Error('chain or chainId required.')
     }
 
     if (signer && walletClient) {
@@ -94,7 +94,7 @@ class TokenboundClient {
       throw new Error('`publicClient` cannot be provided when using Ethers `signer`.')
     }
 
-    this.chainId = chainId
+    this.chainId = chainId ?? chain!.id
 
     if (signer) {
       this.signer = signer
@@ -109,7 +109,6 @@ class TokenboundClient {
       this.registryAddress = registryAddress
     }
 
-    //
     this.publicClient =
       publicClient ??
       createPublicClient({

--- a/packages/sdk/src/TokenboundClient.ts
+++ b/packages/sdk/src/TokenboundClient.ts
@@ -67,6 +67,7 @@ class TokenboundClient {
   constructor(options: TokenboundClientOptions) {
     const {
       chainId,
+      chain,
       signer,
       walletClient,
       publicClient,
@@ -112,7 +113,7 @@ class TokenboundClient {
     this.publicClient =
       publicClient ??
       createPublicClient({
-        chain: chainIdToChain(this.chainId),
+        chain: chain ?? chainIdToChain(this.chainId),
         transport: http(publicClientRPCUrl ?? undefined),
       })
 

--- a/packages/sdk/src/test/TestAll.test.ts
+++ b/packages/sdk/src/test/TestAll.test.ts
@@ -1,6 +1,7 @@
 // This test suite is for testing the SDK methods with
 // viem walletClient + publicClient and with Ethers 5/6.
 
+import { zora } from 'viem/chains'
 import { describe, expect, it, vi } from 'vitest'
 import { providers } from 'ethers'
 import { waitFor } from './mockWallet'
@@ -768,7 +769,7 @@ function runTxTests({
   })
 }
 
-describe('Custom publicClient RPC URL', () => {
+describe('Custom client configurations', () => {
   it('can use a custom publicClient RPC URL', async () => {
     const customPublicClientRPCUrl = 'https://cloudflare-eth.com'
     const tokenboundClient = new TokenboundClient({
@@ -779,6 +780,19 @@ describe('Custom publicClient RPC URL', () => {
 
     await waitFor(() => {
       expect(tokenboundClient.publicClient?.transport?.url).toBe(customPublicClientRPCUrl)
+    })
+  })
+  it('can use a custom chain as parameter', async () => {
+    const ZORA_CHAIN_ID = 7777777
+
+    const tokenboundClient = new TokenboundClient({
+      chainId: ZORA_CHAIN_ID,
+      walletClient,
+      chain: zora,
+    })
+
+    await waitFor(() => {
+      expect(tokenboundClient.publicClient?.chain?.id).toBe(ZORA_CHAIN_ID)
     })
   })
 })

--- a/packages/sdk/src/test/TestAll.test.ts
+++ b/packages/sdk/src/test/TestAll.test.ts
@@ -786,7 +786,6 @@ describe('Custom client configurations', () => {
     const ZORA_CHAIN_ID = 7777777
 
     const tokenboundClient = new TokenboundClient({
-      chainId: ZORA_CHAIN_ID,
       walletClient,
       chain: zora,
     })

--- a/packages/sdk/src/types/params.ts
+++ b/packages/sdk/src/types/params.ts
@@ -1,4 +1,4 @@
-import { WalletClient, PublicClient } from 'viem'
+import { WalletClient, PublicClient, Chain } from 'viem'
 import { Prettify } from './prettify'
 import { UniversalSignableMessage } from './messages'
 import { PossibleENSAddress } from './addresses'
@@ -49,6 +49,7 @@ export type ERC20TransferParams = Prettify<{
 
 export type TokenboundClientOptions = Prettify<{
   chainId: number
+  chain?: Chain
   signer?: any
   walletClient?: WalletClient
   publicClient?: PublicClient

--- a/packages/sdk/src/types/params.ts
+++ b/packages/sdk/src/types/params.ts
@@ -48,7 +48,7 @@ export type ERC20TransferParams = Prettify<{
 }>
 
 export type TokenboundClientOptions = Prettify<{
-  chainId: number
+  chainId?: number
   chain?: Chain
   signer?: any
   walletClient?: WalletClient

--- a/packages/sdk/src/utils/chainIdToChain.ts
+++ b/packages/sdk/src/utils/chainIdToChain.ts
@@ -1,17 +1,40 @@
-import * as allChains from "viem/chains"
-import { Chain } from "viem"
+import { Chain } from 'viem'
+import {
+  mainnet,
+  goerli,
+  polygon,
+  polygonMumbai,
+  sepolia,
+  optimism,
+  arbitrum,
+  base,
+  gnosis,
+} from 'viem/chains'
+
+const allChains = {
+  mainnet,
+  goerli,
+  polygon,
+  polygonMumbai,
+  sepolia,
+  optimism,
+  arbitrum,
+  base,
+  gnosis,
+}
 
 /**
  * Gets the chain object for the given chain id.
  * @param chainId - Chain id of the target EVM chain.
  * @returns Viem's chain object.
  */
+
 export function chainIdToChain(chainId: number): Chain {
   for (const chain of Object.values(allChains)) {
     if (chain.id === chainId) {
       return chain
     }
   }
-  
+
   throw new Error(`Chain with id ${chainId} not found`)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 6.0.3
       connectkit:
         specifier: ^1.5.3
-        version: 1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.15.1)(wagmi@1.4.3)
+        version: 1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.16.2)(wagmi@1.4.3)
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -69,11 +69,11 @@ importers:
         specifier: ^0.12.5
         version: 0.12.5
       viem:
-        specifier: ^1.15.1
-        version: 1.15.1(typescript@5.2.2)
+        specifier: ^1.16.2
+        version: 1.16.2(typescript@5.2.2)(zod@3.21.4)
       wagmi:
         specifier: ^1.4.3
-        version: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1)
+        version: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2)
     devDependencies:
       '@types/react':
         specifier: ^18.2.21
@@ -95,7 +95,7 @@ importers:
     dependencies:
       '@rainbow-me/rainbowkit':
         specifier: ^1.0.11
-        version: 1.0.11(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(viem@1.15.1)(wagmi@1.4.3)
+        version: 1.0.11(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(viem@1.16.2)(wagmi@1.4.3)
       '@tokenbound/sdk':
         specifier: workspace:^
         version: link:../../packages/sdk
@@ -118,11 +118,11 @@ importers:
         specifier: ^0.12.5
         version: 0.12.5
       viem:
-        specifier: ^1.15.1
-        version: 1.15.1(typescript@5.2.2)
+        specifier: ^1.16.2
+        version: 1.16.2(typescript@5.2.2)(zod@3.21.4)
       wagmi:
         specifier: ^1.4.3
-        version: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1)
+        version: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2)
     devDependencies:
       '@types/react':
         specifier: ^18.2.21
@@ -150,7 +150,7 @@ importers:
         version: 6.0.3
       connectkit:
         specifier: ^1.5.3
-        version: 1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.15.1)(wagmi@1.4.3)
+        version: 1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.16.2)(wagmi@1.4.3)
       ethers:
         specifier: ^6.7.0
         version: 6.7.0
@@ -167,11 +167,11 @@ importers:
         specifier: ^0.12.5
         version: 0.12.5
       viem:
-        specifier: ^1.15.1
-        version: 1.15.1(typescript@5.2.2)
+        specifier: ^1.16.2
+        version: 1.16.2(typescript@5.2.2)(zod@3.21.4)
       wagmi:
         specifier: ^1.4.3
-        version: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1)
+        version: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2)
     devDependencies:
       '@types/react':
         specifier: ^18.2.21
@@ -199,7 +199,7 @@ importers:
         version: 6.0.3
       connectkit:
         specifier: ^1.5.3
-        version: 1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.15.1)(wagmi@1.4.3)
+        version: 1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.16.2)(wagmi@1.4.3)
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -216,11 +216,11 @@ importers:
         specifier: ^0.12.5
         version: 0.12.5
       viem:
-        specifier: ^1.15.1
-        version: 1.15.1(typescript@5.2.2)
+        specifier: ^1.16.2
+        version: 1.16.2(typescript@5.2.2)(zod@3.21.4)
       wagmi:
         specifier: ^1.4.3
-        version: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1)
+        version: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2)
     devDependencies:
       '@types/react':
         specifier: ^18.2.21
@@ -271,8 +271,8 @@ importers:
   packages/sdk:
     dependencies:
       viem:
-        specifier: ^1.14.0
-        version: 1.14.0(typescript@5.2.2)(zod@3.21.4)
+        specifier: ^1.16.2
+        version: 1.16.2(typescript@5.2.2)(zod@3.21.4)
     devDependencies:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.1.0
@@ -318,7 +318,7 @@ importers:
         version: 1.5.0(typescript@5.2.2)(wagmi@1.4.3)
       connectkit:
         specifier: ^1.5.3
-        version: 1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.14.0)(wagmi@1.4.3)
+        version: 1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.16.2)(wagmi@1.4.3)
       eslint:
         specifier: ^8.50.0
         version: 8.50.0
@@ -363,7 +363,7 @@ importers:
         version: 0.34.2(jsdom@22.1.0)
       wagmi:
         specifier: ^1.4.3
-        version: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.14.0)
+        version: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2)
 
 packages:
 
@@ -2087,7 +2087,7 @@ packages:
     resolution: {integrity: sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug==}
     dev: true
 
-  /@rainbow-me/rainbowkit@1.0.11(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(viem@1.15.1)(wagmi@1.4.3):
+  /@rainbow-me/rainbowkit@1.0.11(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(viem@1.16.2)(wagmi@1.4.3):
     resolution: {integrity: sha512-+cm6+WUPG9iPgkfJKbvlowcrSHu266Zk20LVRsYLcmb6v29gVMHcWQvyI4T6EVC9TxNjnyq/jIlen++uiUBmmQ==}
     engines: {node: '>=12.4'}
     peerDependencies:
@@ -2104,8 +2104,8 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-remove-scroll: 2.5.4(@types/react@18.2.21)(react@18.2.0)
-      viem: 1.15.1(typescript@5.2.2)
-      wagmi: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1)
+      viem: 1.16.2(typescript@5.2.2)(zod@3.21.4)
+      wagmi: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2)
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -2240,7 +2240,7 @@ packages:
     resolution: {integrity: sha512-gYw0ki/EAuV1oSyMxpqandHjnthZjYYy+YWpTAzf8BqfXM3ItcZLpjxfg+3+mXW8HIO+3jw6T9iiqEXsqHaMMw==}
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.7.0
-      viem: 1.15.1(typescript@5.2.2)
+      viem: 1.16.2(typescript@5.2.2)(zod@3.21.4)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2662,11 +2662,6 @@ packages:
 
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
-    dependencies:
-      '@types/node': 18.15.13
-
-  /@types/ws@8.5.5:
-    resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
       '@types/node': 18.15.13
 
@@ -3102,8 +3097,8 @@ packages:
       picocolors: 1.0.0
       prettier: 2.8.8
       typescript: 5.2.2
-      viem: 1.14.0(typescript@5.2.2)(zod@3.21.4)
-      wagmi: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.14.0)
+      viem: 1.16.2(typescript@5.2.2)(zod@3.21.4)
+      wagmi: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2)
       zod: 3.21.4
     transitivePeerDependencies:
       - bufferutil
@@ -3183,7 +3178,7 @@ packages:
       - zod
     dev: true
 
-  /@wagmi/connectors@3.1.2(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.14.0):
+  /@wagmi/connectors@3.1.2(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2):
     resolution: {integrity: sha512-IlLKErqCzQRBUcCvXGPowcczbWcvJtEG006gPsAoePNJEXCHEWoKASghgu+L/bqD7006Z6mW6zlTNjcSQJvFAg==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -3203,7 +3198,7 @@ packages:
       abitype: 0.8.7(typescript@5.2.2)(zod@3.21.4)
       eventemitter3: 4.0.7
       typescript: 5.2.2
-      viem: 1.14.0(typescript@5.2.2)(zod@3.21.4)
+      viem: 1.16.2(typescript@5.2.2)(zod@3.21.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - '@types/react'
@@ -3214,40 +3209,6 @@ packages:
       - supports-color
       - utf-8-validate
       - zod
-    dev: true
-
-  /@wagmi/connectors@3.1.2(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1):
-    resolution: {integrity: sha512-IlLKErqCzQRBUcCvXGPowcczbWcvJtEG006gPsAoePNJEXCHEWoKASghgu+L/bqD7006Z6mW6zlTNjcSQJvFAg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      viem: '>=0.3.35'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@coinbase/wallet-sdk': 3.6.6
-      '@ledgerhq/connect-kit-loader': 1.1.0
-      '@safe-global/safe-apps-provider': 0.17.1(typescript@5.2.2)
-      '@safe-global/safe-apps-sdk': 8.0.0(typescript@5.2.2)
-      '@walletconnect/ethereum-provider': 2.10.1(@walletconnect/modal@2.6.2)
-      '@walletconnect/legacy-provider': 2.0.0
-      '@walletconnect/modal': 2.6.2(@types/react@18.2.21)(react@18.2.0)
-      '@walletconnect/utils': 2.10.1
-      abitype: 0.8.7(typescript@5.2.2)(zod@3.21.4)
-      eventemitter3: 4.0.7
-      typescript: 5.2.2
-      viem: 1.15.1(typescript@5.2.2)
-    transitivePeerDependencies:
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - bufferutil
-      - encoding
-      - lokijs
-      - react
-      - supports-color
-      - utf-8-validate
-      - zod
-    dev: false
 
   /@wagmi/core@0.10.0(ethers@5.7.2)(react@18.2.0)(typescript@4.9.4):
     resolution: {integrity: sha512-biDjKhN9H/hEsbdWfIXovV90nHdwnO3urUTlZVX8fsntg8d9TFQFxhjRCgspHfXcznfRGbUHVslPyQoup1wvrg==}
@@ -3310,7 +3271,7 @@ packages:
       - zod
     dev: true
 
-  /@wagmi/core@1.4.3(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.14.0):
+  /@wagmi/core@1.4.3(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2):
     resolution: {integrity: sha512-CIV9jwv5ue+WpqmA3FvwGa+23cppe7oIaz6TRnlGm0Hm0wDImSaQSWqcsFyOPvleD29oOIJ8e3KnHINEvI64AA==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -3319,11 +3280,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@wagmi/connectors': 3.1.2(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.14.0)
+      '@wagmi/connectors': 3.1.2(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2)
       abitype: 0.8.7(typescript@5.2.2)(zod@3.21.4)
       eventemitter3: 4.0.7
       typescript: 5.2.2
-      viem: 1.14.0(typescript@5.2.2)(zod@3.21.4)
+      viem: 1.16.2(typescript@5.2.2)(zod@3.21.4)
       zustand: 4.3.7(react@18.2.0)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -3336,35 +3297,6 @@ packages:
       - supports-color
       - utf-8-validate
       - zod
-    dev: true
-
-  /@wagmi/core@1.4.3(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1):
-    resolution: {integrity: sha512-CIV9jwv5ue+WpqmA3FvwGa+23cppe7oIaz6TRnlGm0Hm0wDImSaQSWqcsFyOPvleD29oOIJ8e3KnHINEvI64AA==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      viem: '>=0.3.35'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@wagmi/connectors': 3.1.2(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1)
-      abitype: 0.8.7(typescript@5.2.2)(zod@3.21.4)
-      eventemitter3: 4.0.7
-      typescript: 5.2.2
-      viem: 1.15.1(typescript@5.2.2)
-      zustand: 4.3.7(react@18.2.0)
-    transitivePeerDependencies:
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - bufferutil
-      - encoding
-      - immer
-      - lokijs
-      - react
-      - supports-color
-      - utf-8-validate
-      - zod
-    dev: false
 
   /@walletconnect/core@2.10.0:
     resolution: {integrity: sha512-Z8pdorfIMueuiBXLdnf7yloiO9JIiobuxN3j0OTal+MYc4q5/2O7d+jdD1DAXbLi1taJx3x60UXT/FPVkjIqIQ==}
@@ -4774,7 +4706,7 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
-  /connectkit@1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.14.0)(wagmi@1.4.3):
+  /connectkit@1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.16.2)(wagmi@1.4.3):
     resolution: {integrity: sha512-vXneVOa+oit5Migoxca2QkgVBHaROItzb2kW13o7aUrcEcecYIGZjsizsVM2YvIdKihyWs+zJFrlED4g8zAMew==}
     engines: {node: '>=12.4'}
     peerDependencies:
@@ -4793,36 +4725,10 @@ packages:
       react-use-measure: 2.1.1(react-dom@18.2.0)(react@18.2.0)
       resize-observer-polyfill: 1.5.1
       styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-      viem: 1.14.0(typescript@5.2.2)(zod@3.21.4)
-      wagmi: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.14.0)
+      viem: 1.16.2(typescript@5.2.2)(zod@3.21.4)
+      wagmi: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2)
     transitivePeerDependencies:
       - react-is
-    dev: true
-
-  /connectkit@1.5.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(viem@1.15.1)(wagmi@1.4.3):
-    resolution: {integrity: sha512-vXneVOa+oit5Migoxca2QkgVBHaROItzb2kW13o7aUrcEcecYIGZjsizsVM2YvIdKihyWs+zJFrlED4g8zAMew==}
-    engines: {node: '>=12.4'}
-    peerDependencies:
-      react: 17.x || 18.x
-      react-dom: 17.x || 18.x
-      viem: ^1.0.0
-      wagmi: ^1.1.1
-    dependencies:
-      buffer: 6.0.3
-      detect-browser: 5.3.0
-      framer-motion: 6.5.1(react-dom@18.2.0)(react@18.2.0)
-      qrcode: 1.5.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-transition-state: 1.1.5(react-dom@18.2.0)(react@18.2.0)
-      react-use-measure: 2.1.1(react-dom@18.2.0)(react@18.2.0)
-      resize-observer-polyfill: 1.5.1
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-      viem: 1.15.1(typescript@5.2.2)
-      wagmi: 1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1)
-    transitivePeerDependencies:
-      - react-is
-    dev: false
 
   /constant-case@3.0.4:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
@@ -6816,6 +6722,14 @@ packages:
 
   /isomorphic-ws@5.0.0(ws@8.13.0):
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+    dependencies:
+      ws: 8.13.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    dev: true
+
+  /isows@1.0.3(ws@8.13.0):
+    resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
     peerDependencies:
       ws: '*'
     dependencies:
@@ -9297,8 +9211,8 @@ packages:
       - zod
     dev: true
 
-  /viem@1.14.0(typescript@5.2.2)(zod@3.21.4):
-    resolution: {integrity: sha512-4d+4/H3lnbkSAbrpQ15i1nBA7hne06joLFy3L3m0ZpMc+g+Zr3D4nuSTyeiqbHAYs9m2P9Kjap0HlyGkehasgg==}
+  /viem@1.16.2(typescript@5.2.2)(zod@3.21.4):
+    resolution: {integrity: sha512-ZQ8kemNvRVwucwcsj4/SjKohK+wZv9Vxx/gXAlwqGMCW7r+niOeECtFku/1L7UPTmPgdmq4kic9R71t6XQDmGw==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -9310,32 +9224,8 @@ packages:
       '@noble/hashes': 1.3.2
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
-      '@types/ws': 8.5.5
       abitype: 0.9.8(typescript@5.2.2)(zod@3.21.4)
-      isomorphic-ws: 5.0.0(ws@8.13.0)
-      typescript: 5.2.2
-      ws: 8.13.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  /viem@1.15.1(typescript@5.2.2):
-    resolution: {integrity: sha512-lxk8wwUK7ZivYAUZ6pH+9Y6jjrfXXjafCOoASa4lw3ULUCT2BajU4SELarlxJQimpsFd7OZD4m4iEXYLF/bt6w==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@adraffy/ens-normalize': 1.9.4
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@scure/bip32': 1.3.2
-      '@scure/bip39': 1.2.1
-      '@types/ws': 8.5.5
-      abitype: 0.9.8(typescript@5.2.2)(zod@3.21.4)
-      isomorphic-ws: 5.0.0(ws@8.13.0)
+      isows: 1.0.3(ws@8.13.0)
       typescript: 5.2.2
       ws: 8.13.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -9609,7 +9499,7 @@ packages:
       - zod
     dev: true
 
-  /wagmi@1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.14.0):
+  /wagmi@1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2):
     resolution: {integrity: sha512-3LjbqqVRe6WW/WD07QCd5Itmo4nUfLsXuoc8F7nw9NslNUg8SFEb+g/jZ4665V0xh5ZRqPBJ7XOXASpdM2Y/5Q==}
     peerDependencies:
       react: '>=17.0.0'
@@ -9622,12 +9512,12 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.29.1
       '@tanstack/react-query': 4.29.1(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-persist-client': 4.29.1(@tanstack/react-query@4.29.1)
-      '@wagmi/core': 1.4.3(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.14.0)
+      '@wagmi/core': 1.4.3(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.16.2)
       abitype: 0.8.7(typescript@5.2.2)(zod@3.21.4)
       react: 18.2.0
       typescript: 5.2.2
       use-sync-external-store: 1.2.0(react@18.2.0)
-      viem: 1.14.0(typescript@5.2.2)(zod@3.21.4)
+      viem: 1.16.2(typescript@5.2.2)(zod@3.21.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - '@types/react'
@@ -9640,40 +9530,6 @@ packages:
       - supports-color
       - utf-8-validate
       - zod
-    dev: true
-
-  /wagmi@1.4.3(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1):
-    resolution: {integrity: sha512-3LjbqqVRe6WW/WD07QCd5Itmo4nUfLsXuoc8F7nw9NslNUg8SFEb+g/jZ4665V0xh5ZRqPBJ7XOXASpdM2Y/5Q==}
-    peerDependencies:
-      react: '>=17.0.0'
-      typescript: '>=5.0.4'
-      viem: '>=0.3.35'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@tanstack/query-sync-storage-persister': 4.29.1
-      '@tanstack/react-query': 4.29.1(react-dom@18.2.0)(react@18.2.0)
-      '@tanstack/react-query-persist-client': 4.29.1(@tanstack/react-query@4.29.1)
-      '@wagmi/core': 1.4.3(@types/react@18.2.21)(react@18.2.0)(typescript@5.2.2)(viem@1.15.1)
-      abitype: 0.8.7(typescript@5.2.2)(zod@3.21.4)
-      react: 18.2.0
-      typescript: 5.2.2
-      use-sync-external-store: 1.2.0(react@18.2.0)
-      viem: 1.15.1(typescript@5.2.2)
-    transitivePeerDependencies:
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - bufferutil
-      - encoding
-      - immer
-      - lokijs
-      - react-dom
-      - react-native
-      - supports-color
-      - utf-8-validate
-      - zod
-    dev: false
 
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}


### PR DESCRIPTION
Previously, we were importing all chains from viem for use in ```chainIdToChain```:

```typescript
import * as allChains from "viem/chains"
```
This meant that they were all being included in the bundle.

Here we replace it with only the deployed chains:

```typescript
import {
  mainnet,
  goerli,
  polygon,
  polygonMumbai,
  sepolia,
  optimism,
  arbitrum,
  base,
  gnosis,
} from 'viem/chains'
```

and then allow an optional chain parameter to be passed when the TokenboundClient is instantiated in case anyone needs to make use of the SDK using chains for which we don't have record of deployment.

This results in a ~42% decrease in package size.

**Before:**  
```bash
[vite:dts] Start generate declaration files...
dist/tokenbound-sdk.js  184.42 kB │ gzip: 48.90 kB
[vite:dts] Declaration files built in 2871ms.

dist/tokenbound-sdk.umd.cjs  137.49 kB │ gzip: 44.62 kB
```

**After:** 
```bash
[vite:dts] Start generate declaration files...
dist/tokenbound-sdk.js  79.76 kB │ gzip: 34.29 kB
[vite:dts] Declaration files built in 2549ms.

dist/tokenbound-sdk.umd.cjs  60.03 kB │ gzip: 31.77 kB
```