### PR TITLE
add version and implementation address to window.tokenboundSDK

### DIFF
--- a/packages/sdk/src/TokenboundClient.ts
+++ b/packages/sdk/src/TokenboundClient.ts
@@ -54,7 +54,13 @@ import {
   isViemSignableMessage,
   resolvePossibleENS,
 } from './utils'
+import { version as TB_SDK_VERSION } from '../package.json'
 
+declare global {
+  interface Window {
+    tokenboundSDK?: string
+  }
+}
 class TokenboundClient {
   private chainId: number
   public isInitialized: boolean = false
@@ -117,6 +123,12 @@ class TokenboundClient {
       })
 
     this.isInitialized = true
+
+    if (typeof window !== 'undefined') {
+      window.tokenboundSDK = `Tokenbound SDK ${TB_SDK_VERSION} Implementation: ${
+        this.implementationAddress ?? 'Default'
+      }`
+    }
   }
 
   /**


### PR DESCRIPTION
In order to confirm which implementation and SDK version are in use for debugging, we write them to `window.tokenboundSDK` when the TokenboundClient is instantiated.