### PR TITLE
Add OP goerli to internal chains

### DIFF
--- a/packages/sdk/src/utils/chainIdToChain.ts
+++ b/packages/sdk/src/utils/chainIdToChain.ts
@@ -7,6 +7,7 @@ import {
   sepolia,
   optimism,
   arbitrum,
+  optimismGoerli,
   base,
   gnosis,
 } from 'viem/chains'
@@ -14,6 +15,7 @@ import {
 const allChains = {
   mainnet,
   goerli,
+  optimismGoerli,
   polygon,
   polygonMumbai,
   sepolia,


### PR DESCRIPTION
OP Goerli was deployed as a standard deployment on V3, so we include it in the package.