### PR TITLE
Ensure init in createAccount when TBClient is instantiated with default V3 implementationAddress

### DIFF
--- a/.github/workflows/on-create-release.yml
+++ b/.github/workflows/on-create-release.yml
@@ -30,7 +30,7 @@ jobs:
         run: cd packages/sdk
 
       - name: Install dependencies
-        run: cd packages/sdk && npm install
+        run: npm install
 
       - name: Clean install and build 🔧
         run: cd packages/sdk && npm ci && npm run build

--- a/packages/sdk/src/TokenboundClient.ts
+++ b/packages/sdk/src/TokenboundClient.ts
@@ -219,6 +219,9 @@ class TokenboundClient {
     const implementation =
       this.implementationAddress ?? ERC_6551_DEFAULT.ACCOUNT_PROXY!.ADDRESS
     const registry = this.registryAddress ?? ERC_6551_DEFAULT.REGISTRY.ADDRESS
+    const isCustomImplementation =
+      this.implementationAddress &&
+      !isAddressEqual(this.implementationAddress, ERC_6551_DEFAULT.ACCOUNT_PROXY!.ADDRESS)
 
     try {
       let txHash: `0x${string}` | undefined
@@ -248,7 +251,7 @@ class TokenboundClient {
             data: `0x${string}`
           }
 
-      if (this.implementationAddress) {
+      if (isCustomImplementation) {
         // Don't initalize for custom implementations. Allow third-party handling of initialization.
         prepareCreateV3Account = prepareCreateAccount
       } else {


### PR DESCRIPTION
Quick fix for issue where passing V3 implementationAddress would skip the multicall init flow.