### PR TITLE
Add explicit publish branch to github workflow

### DIFF
--- a/.github/workflows/on-create-release.yml
+++ b/.github/workflows/on-create-release.yml
@@ -36,6 +36,6 @@ jobs:
         # run: pnpm ci && pnpm build // pnpm ci not yet implemented: https://github.com/pnpm/pnpm/issues/6100
 
       - name: Publish package on NPM 📦
-        run: cd packages/sdk && pnpm publish
+        run: cd packages/sdk && pnpm publish --publish-branch main --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
Workflow failed with ```ERR_PNPM_GIT_UNKNOWN_BRANCH The Git HEAD may not attached to any branch, but your "publish-branch" is set to "master|main"```