### PR TITLE
Parameterized tests to allow for easier isolation while running

### DIFF
--- a/packages/sdk/src/test/config/anvil.ts
+++ b/packages/sdk/src/test/config/anvil.ts
@@ -9,10 +9,5 @@ export const ANVIL_CONFIG = {
 }
 
 export const CREATE_ANVIL_OPTIONS: CreateAnvilOptions = {
-  // noStorageCaching: true,
-  forkChainId: ACTIVE_CHAIN.id,
   forkUrl: import.meta.env.VITE_ANVIL_MAINNET_FORK_ENDPOINT,
-  forkBlockNumber: import.meta.env.VITE_ANVIL_MAINNET_FORK_BLOCK_NUMBER
-    ? parseInt(import.meta.env.VITE_ANVIL_MAINNET_FORK_BLOCK_NUMBER)
-    : undefined,
 }

--- a/packages/sdk/src/test/tokenboundClient.test.ts
+++ b/packages/sdk/src/test/tokenboundClient.test.ts
@@ -5,135 +5,126 @@ import { TEST_CONFIG, TEST_RESULTS } from './config'
 import { ERC_6551_LEGACY_V2 } from '../constants'
 import { TBVersion } from '../types'
 
-describe('Test SDK write methods across standard implementations', () => {
-  runTests({
+describe.each([
+  {
     testName: 'v2',
     expectedTestResults: TEST_RESULTS.V2,
     implementationAddress: ERC_6551_LEGACY_V2.IMPLEMENTATION.ADDRESS,
     registryAddress: ERC_6551_LEGACY_V2.REGISTRY.ADDRESS,
-  })
-  runTests({ testName: 'v3', expectedTestResults: TEST_RESULTS.V3 })
-})
-
-function runTests({
-  testName,
-  expectedTestResults,
-  implementationAddress,
-  registryAddress,
-}: {
-  testName: string
-  expectedTestResults: Object
-  implementationAddress?: `0x${string}`
-  registryAddress?: `0x${string}`
-}) {
-  const tokenboundClient = new TokenboundClient({
-    chainId: TEST_CONFIG.CHAIN_ID,
-    version: testName === 'v2' ? TBVersion.V2 : TBVersion.V3,
-    implementationAddress,
-    registryAddress,
-  })
-
-  test(`tokenboundClient.getAccount ${testName}`, () => {
-    const result = tokenboundClient.getAccount({
-      tokenContract: TEST_CONFIG.TOKEN_CONTRACT,
-      tokenId: TEST_CONFIG.TOKEN_ID,
-    })
-    expect(result).toEqual(expectedTestResults['TB_ACCOUNT'])
-  })
-
-  test.todo('tokenboundClient.getCreationCode')
-
-  if (testName === 'v2') {
-    test(`tokenboundClient.prepareExecuteCall ${testName}`, async () => {
-      const preparedCall = await tokenboundClient.prepareExecuteCall({
-        account: TEST_CONFIG.TB_ACCOUNT,
-        to: TEST_CONFIG.RECIPIENT_ADDRESS,
-        value: 0n,
-        data: TEST_CONFIG.EXAMPLE_DATA,
-      })
-
-      expect(isAddress(preparedCall.to)).toEqual(true)
-      expect(typeof preparedCall.value).toEqual('bigint')
-      expect(isHex(preparedCall.data)).toEqual(true)
-    })
-  }
-  if (testName === 'v3') {
-    test(`tokenboundClient.prepareExecution ${testName}`, async () => {
-      const preparedCall = await tokenboundClient.prepareExecution({
-        account: TEST_CONFIG.TB_ACCOUNT,
-        to: TEST_CONFIG.RECIPIENT_ADDRESS,
-        value: 0n,
-        data: TEST_CONFIG.EXAMPLE_DATA,
-      })
-
-      expect(isAddress(preparedCall.to)).toEqual(true)
-      expect(typeof preparedCall.value).toEqual('bigint')
-      expect(isHex(preparedCall.data)).toEqual(true)
-    })
-  }
-
-  test.todo('tokenboundClient.executeCall')
-
-  test(`tokenboundClient.prepareCreateAccount ${testName}`, async () => {
-    const preparedAccount = await tokenboundClient.prepareCreateAccount({
-      tokenContract: TEST_CONFIG.TOKEN_CONTRACT,
-      tokenId: TEST_CONFIG.TOKEN_ID,
-    })
-
-    expect(isAddress(preparedAccount.to)).toEqual(true)
-    expect(typeof preparedAccount.value).toEqual('bigint')
-    expect(isHex(preparedAccount.data)).toEqual(true)
-  })
-
-  test(`tokenboundClient.checkAccountDeployment ${testName}`, async () => {
-    const isSapienz0Deployed = await tokenboundClient.checkAccountDeployment({
-      accountAddress: TEST_CONFIG.SAPIENZ_GOERLI_TOKEN_TBA_TOKENID_0,
-    })
-    const isSapienz1Deployed = await tokenboundClient.checkAccountDeployment({
-      accountAddress: TEST_CONFIG.SAPIENZ_GOERLI_TOKEN_TBA_TOKENID_1,
-    })
-
-    expect(isSapienz0Deployed).toEqual(true)
-    expect(isSapienz1Deployed).toEqual(false)
-  })
-
-  test(`tokenboundClient.deconstructBytecode ${testName}`, async () => {
-    const bytecode = await tokenboundClient.deconstructBytecode({
-      accountAddress: TEST_CONFIG.SAPIENZ_GOERLI_TOKEN_TBA_TOKENID_0,
-    })
-
-    if (!bytecode) throw new Error('Bytecode is undefined')
-
-    const {
-      chainId,
+  },
+  { testName: 'v3', expectedTestResults: TEST_RESULTS.V3 },
+])(
+  'Test SDK write methods across standard implementations $testName',
+  ({ testName, expectedTestResults, implementationAddress, registryAddress }) => {
+    const tokenboundClient = new TokenboundClient({
+      chainId: TEST_CONFIG.CHAIN_ID,
+      version: testName === 'v2' ? TBVersion.V2 : TBVersion.V3,
       implementationAddress,
-      tokenContract,
-      tokenId,
-      salt,
-      erc1167Header,
-      erc1167Footer,
-    } = bytecode
-
-    expect(chainId).toEqual(TEST_CONFIG.CHAIN_ID)
-    expect(erc1167Header).toEqual(TEST_CONFIG.ERC1167_HEADER)
-    expect(implementationAddress).toEqual(ERC_6551_LEGACY_V2.IMPLEMENTATION.ADDRESS)
-    expect(erc1167Footer).toEqual(TEST_CONFIG.ERC1167_FOOTER)
-    expect(tokenContract).toEqual(TEST_CONFIG.SAPIENZ_GOERLI_CONTRACT)
-    expect(tokenId).toEqual('0')
-    expect(salt).toEqual(0)
-  })
-
-  test(`tokenboundClient.getNFT ${testName}`, async () => {
-    const nft = await tokenboundClient.getNFT({
-      accountAddress: TEST_CONFIG.SAPIENZ_GOERLI_TOKEN_TBA_TOKENID_0,
+      registryAddress,
     })
 
-    if (!nft) throw new Error('Bytecode is undefined')
+    test(`tokenboundClient.getAccount ${testName}`, () => {
+      const result = tokenboundClient.getAccount({
+        tokenContract: TEST_CONFIG.TOKEN_CONTRACT,
+        tokenId: TEST_CONFIG.TOKEN_ID,
+      })
+      expect(result).toEqual(expectedTestResults['TB_ACCOUNT'])
+    })
 
-    const { chainId, tokenContract, tokenId } = nft
+    test.todo('tokenboundClient.getCreationCode')
 
-    expect(chainId).toEqual(TEST_CONFIG.CHAIN_ID)
-    expect(tokenContract).toEqual(TEST_CONFIG.SAPIENZ_GOERLI_CONTRACT)
-    expect(tokenId).toEqual('0')
-  })
-}
+    if (testName === 'v2') {
+      test(`tokenboundClient.prepareExecuteCall ${testName}`, async () => {
+        const preparedCall = await tokenboundClient.prepareExecuteCall({
+          account: TEST_CONFIG.TB_ACCOUNT,
+          to: TEST_CONFIG.RECIPIENT_ADDRESS,
+          value: 0n,
+          data: TEST_CONFIG.EXAMPLE_DATA,
+        })
+
+        expect(isAddress(preparedCall.to)).toEqual(true)
+        expect(typeof preparedCall.value).toEqual('bigint')
+        expect(isHex(preparedCall.data)).toEqual(true)
+      })
+    }
+    if (testName === 'v3') {
+      test(`tokenboundClient.prepareExecution ${testName}`, async () => {
+        const preparedCall = await tokenboundClient.prepareExecution({
+          account: TEST_CONFIG.TB_ACCOUNT,
+          to: TEST_CONFIG.RECIPIENT_ADDRESS,
+          value: 0n,
+          data: TEST_CONFIG.EXAMPLE_DATA,
+        })
+
+        expect(isAddress(preparedCall.to)).toEqual(true)
+        expect(typeof preparedCall.value).toEqual('bigint')
+        expect(isHex(preparedCall.data)).toEqual(true)
+      })
+    }
+
+    test.todo('tokenboundClient.executeCall')
+
+    test(`tokenboundClient.prepareCreateAccount ${testName}`, async () => {
+      const preparedAccount = await tokenboundClient.prepareCreateAccount({
+        tokenContract: TEST_CONFIG.TOKEN_CONTRACT,
+        tokenId: TEST_CONFIG.TOKEN_ID,
+      })
+
+      expect(isAddress(preparedAccount.to)).toEqual(true)
+      expect(typeof preparedAccount.value).toEqual('bigint')
+      expect(isHex(preparedAccount.data)).toEqual(true)
+    })
+
+    test(`tokenboundClient.checkAccountDeployment ${testName}`, async () => {
+      const isSapienz0Deployed = await tokenboundClient.checkAccountDeployment({
+        accountAddress: TEST_CONFIG.SAPIENZ_GOERLI_TOKEN_TBA_TOKENID_0,
+      })
+      const isSapienz1Deployed = await tokenboundClient.checkAccountDeployment({
+        accountAddress: TEST_CONFIG.SAPIENZ_GOERLI_TOKEN_TBA_TOKENID_1,
+      })
+
+      expect(isSapienz0Deployed).toEqual(true)
+      expect(isSapienz1Deployed).toEqual(false)
+    })
+
+    test(`tokenboundClient.deconstructBytecode ${testName}`, async () => {
+      const bytecode = await tokenboundClient.deconstructBytecode({
+        accountAddress: TEST_CONFIG.SAPIENZ_GOERLI_TOKEN_TBA_TOKENID_0,
+      })
+
+      if (!bytecode) throw new Error('Bytecode is undefined')
+
+      const {
+        chainId,
+        implementationAddress,
+        tokenContract,
+        tokenId,
+        salt,
+        erc1167Header,
+        erc1167Footer,
+      } = bytecode
+
+      expect(chainId).toEqual(TEST_CONFIG.CHAIN_ID)
+      expect(erc1167Header).toEqual(TEST_CONFIG.ERC1167_HEADER)
+      expect(implementationAddress).toEqual(ERC_6551_LEGACY_V2.IMPLEMENTATION.ADDRESS)
+      expect(erc1167Footer).toEqual(TEST_CONFIG.ERC1167_FOOTER)
+      expect(tokenContract).toEqual(TEST_CONFIG.SAPIENZ_GOERLI_CONTRACT)
+      expect(tokenId).toEqual('0')
+      expect(salt).toEqual(0)
+    })
+
+    test(`tokenboundClient.getNFT ${testName}`, async () => {
+      const nft = await tokenboundClient.getNFT({
+        accountAddress: TEST_CONFIG.SAPIENZ_GOERLI_TOKEN_TBA_TOKENID_0,
+      })
+
+      if (!nft) throw new Error('Bytecode is undefined')
+
+      const { chainId, tokenContract, tokenId } = nft
+
+      expect(chainId).toEqual(TEST_CONFIG.CHAIN_ID)
+      expect(tokenContract).toEqual(TEST_CONFIG.SAPIENZ_GOERLI_CONTRACT)
+      expect(tokenId).toEqual('0')
+    })
+  }
+)

--- a/packages/sdk/src/test/viemV2.test.ts
+++ b/packages/sdk/src/test/viemV2.test.ts
@@ -12,79 +12,70 @@ import {
 import { TEST_CONFIG, TEST_RESULTS } from './config'
 import { ERC_6551_LEGACY_V2 } from '../constants'
 
-describe('Test SDK read methods across standard implementations', () => {
-  runTests({
+describe.each([
+  {
     testName: 'v2',
     expectedTestResults: TEST_RESULTS.V2,
     implementationAddress: ERC_6551_LEGACY_V2.IMPLEMENTATION.ADDRESS,
     registryAddress: ERC_6551_LEGACY_V2.REGISTRY.ADDRESS,
-  })
-})
+  },
+])(
+  'Test SDK read methods across standard implementations $testName',
+  ({ testName, expectedTestResults, implementationAddress, registryAddress }) => {
+    test(`.getAccount ${testName}`, async () => {
+      const publicClient = createPublicClient({
+        chain: goerli,
+        transport: http(),
+      })
 
-function runTests({
-  testName,
-  expectedTestResults,
-  implementationAddress,
-  registryAddress,
-}: {
-  testName: string
-  expectedTestResults: Object
-  implementationAddress?: `0x${string}`
-  registryAddress?: `0x${string}`
-}) {
-  test(`.getAccount ${testName}`, async () => {
-    const publicClient = createPublicClient({
-      chain: goerli,
-      transport: http(),
+      const result = await getAccount(
+        TEST_CONFIG.TOKEN_CONTRACT,
+        TEST_CONFIG.TOKEN_ID,
+        publicClient,
+        implementationAddress,
+        registryAddress
+      )
+      expect(result).toEqual(expectedTestResults['TB_ACCOUNT'])
     })
 
-    const result = await getAccount(
-      TEST_CONFIG.TOKEN_CONTRACT,
-      TEST_CONFIG.TOKEN_ID,
-      publicClient,
-      implementationAddress,
-      registryAddress
-    )
-    expect(result).toEqual(expectedTestResults['TB_ACCOUNT'])
-  })
+    test(`computeAccount ${testName}`, async () => {
+      const result = computeAccount(
+        TEST_CONFIG.TOKEN_CONTRACT,
+        TEST_CONFIG.TOKEN_ID,
+        TEST_CONFIG.CHAIN_ID,
+        implementationAddress,
+        registryAddress
+      )
+      expect(result).toEqual(expectedTestResults['TB_ACCOUNT'])
+    })
 
-  test(`computeAccount ${testName}`, async () => {
-    const result = computeAccount(
-      TEST_CONFIG.TOKEN_CONTRACT,
-      TEST_CONFIG.TOKEN_ID,
-      TEST_CONFIG.CHAIN_ID,
-      implementationAddress,
-      registryAddress
-    )
-    expect(result).toEqual(expectedTestResults['TB_ACCOUNT'])
-  })
+    test.todo(`.getCreationCode ${testName}`)
 
-  test.todo(`.getCreationCode ${testName}`)
+    test(`.prepareExecuteCall ${testName}`, async () => {
+      const preparedCall = await prepareExecuteCall(
+        expectedTestResults['TB_ACCOUNT'],
+        TEST_CONFIG.RECIPIENT_ADDRESS,
+        TEST_CONFIG.EXAMPLE_AMOUNT,
+        TEST_CONFIG.EXAMPLE_DATA
+      )
 
-  test(`.prepareExecuteCall ${testName}`, async () => {
-    const preparedCall = await prepareExecuteCall(
-      expectedTestResults['TB_ACCOUNT'],
-      TEST_CONFIG.RECIPIENT_ADDRESS,
-      TEST_CONFIG.EXAMPLE_AMOUNT,
-      TEST_CONFIG.EXAMPLE_DATA
-    )
+      expect(isAddress(preparedCall.to)).toEqual(true)
+      expect(typeof preparedCall.value).toEqual('bigint')
+      expect(isHex(preparedCall.data)).toEqual(true)
+    })
 
-    expect(isAddress(preparedCall.to)).toEqual(true)
-    expect(typeof preparedCall.value).toEqual('bigint')
-    expect(isHex(preparedCall.data)).toEqual(true)
-  })
+    test(`.prepareCreateAccount ${testName}`, async () => {
+      const preparedAccount = await prepareCreateAccount(
+        TEST_CONFIG.TOKEN_CONTRACT,
+        TEST_CONFIG.TOKEN_ID,
+        TEST_CONFIG.CHAIN_ID,
+        implementationAddress,
+        registryAddress
+      )
 
-  test(`.prepareCreateAccount ${testName}`, async () => {
-    const preparedAccount = await prepareCreateAccount(
-      TEST_CONFIG.TOKEN_CONTRACT,
-      TEST_CONFIG.TOKEN_ID,
-      TEST_CONFIG.CHAIN_ID,
-      implementationAddress,
-      registryAddress
-    )
-
-    expect(isAddress(preparedAccount.to)).toEqual(true)
-    expect(typeof preparedAccount.value).toEqual('bigint')
-    expect(isHex(preparedAccount.data)).toEqual(true)
-  })
-}
+      expect(isAddress(preparedAccount.to)).toEqual(true)
+      expect(typeof preparedAccount.value).toEqual('bigint')
+      expect(isHex(preparedAccount.data)).toEqual(true)
+    })
+  }
+)


### PR DESCRIPTION
This PR refactors the test suite to use vitest's built-in parameterization, which makes it easier to run only a subset of the tests at once.

You now test against a single version using `pnpm test -- -t v3` or against a single client library using `pnpm test -- -t ethers@5`.